### PR TITLE
fix(#4): Next.js Support #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A React component for weather icons for use with Open Weather and Yahoo Weather 
 
 ```javascript
 import * as React from 'react';
+// The following CSS file must be installed for use of WeatherIcon.
+import 'weather-react-icons/lib/css/weather-icons.css';
 import { WeatherIcon } from 'weather-react-icons';
 
 const Weather = () => {

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+// the following css file must be installed for WeatherIcon component.
+import 'weather-react-icons/lib/css/weather-icons.css';
 import { WeatherIcon } from 'weather-react-icons';
-// if only use css, import css files as follows
-// import 'weather-react-icons/lib/css/weather-icons.css';
-// import 'weather-react-icons/lib/css/weather-icons-wind.css';
 
 ReactDOM.render(
   <WeatherIcon iconId={201} name="owm" />,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-react-icons",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "tsc && copyfiles -f src/css/*.css lib/css/ ",
+    "build": "tsc && copyfiles -f node_modules/weather-icons/css/*.css lib/css/ && copyfiles -f node_modules/weather-icons/font/**.* lib/font/",
     "test": "jest",
     "lint": "eslint -c ./.eslintrc.json ./src/**/*.{ts,tsx} ./example/**/*.{ts,tsx}",
     "prepublishOnly": "npm run build"

--- a/src/WeatherIcon.tsx
+++ b/src/WeatherIcon.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-// import './css/weather-icons.css';
 import convertCode from './utils/convertCode';
 
 type WeatherIconProps = (

--- a/src/WeatherIcon.tsx
+++ b/src/WeatherIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import './css/weather-icons.css';
+// import './css/weather-icons.css';
 import convertCode from './utils/convertCode';
 
 type WeatherIconProps = (

--- a/src/css/weather-icons-wind.css
+++ b/src/css/weather-icons-wind.css
@@ -1,1 +1,0 @@
-@import '~weather-icons/css/weather-icons-wind.css';

--- a/src/css/weather-icons.css
+++ b/src/css/weather-icons.css
@@ -1,1 +1,0 @@
-@import '~weather-icons/css/weather-icons.css';


### PR DESCRIPTION
### Related Issue
- #4 

### Description
Next.js user got the following error,
```
./node_modules/weather-react-icons/lib/css/weather-icons.css
Global CSS cannot be imported from within node_modules.
Read more: https://err.sh/next.js/css-npm
Location: node_modules/weather-react-icons/lib/WeatherIcon.js
```
because Weather-react-icons have references to other module's CSS files. For more info, please see the [link](https://err.sh/next.js/css-npm).

### Proposed Changes
- Delete the references in lib/css/weather-icons.css and weather-icon-wind.css.
- Rewrite npm scripts as copy the CSS files and paste them to lib/css/ in build time.








